### PR TITLE
Fix the focusing on CalendarDay when isFocused and tabIndex = 0.

### DIFF
--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -18,9 +18,7 @@ const propTypes = {
 
   ...omit(SingleDatePickerShape, [
     'date',
-    'onDateChange',
     'focused',
-    'onFocusChange',
   ]),
 };
 
@@ -28,6 +26,9 @@ const defaultProps = {
   // example props for the demo
   autoFocus: false,
   initialDate: null,
+
+  onDateChange: () => {},
+  onFocusChange: () => {},
 
   // input related props
   id: 'date',
@@ -91,11 +92,17 @@ class SingleDatePickerWrapper extends React.Component {
   }
 
   onDateChange(date) {
+    const { onDateChange } = this.props;
     this.setState({ date });
+
+    onDateChange(date);
   }
 
   onFocusChange({ focused }) {
+    const { onFocusChange } = this.props;
     this.setState({ focused });
+
+    onFocusChange({ focused });
   }
 
   render() {

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -55,6 +55,17 @@ class CalendarDay extends React.PureComponent {
     this.setButtonRef = this.setButtonRef.bind(this);
   }
 
+  componentDidMount() {
+    const { isFocused, tabIndex } = this.props;
+    if (isFocused && tabIndex === 0) {
+      setTimeout(() => {
+        if (this.buttonRef) {
+          this.buttonRef.focus();
+        }
+      }, 0);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -225,6 +225,17 @@ class CustomizableCalendarDay extends React.PureComponent {
     this.setButtonRef = this.setButtonRef.bind(this);
   }
 
+  componentDidMount() {
+    const { isFocused, tabIndex } = this.props;
+    if (isFocused && tabIndex === 0) {
+      setTimeout(() => {
+        if (this.buttonRef) {
+          this.buttonRef.focus();
+        }
+      }, 0);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 import DirectionProvider, { DIRECTIONS } from 'react-with-direction/dist/DirectionProvider';
 import isInclusivelyBeforeDay from '../src/utils/isInclusivelyBeforeDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
@@ -12,9 +13,9 @@ import {
   ANCHOR_RIGHT,
 } from '../src/constants';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from '../examples/SingleDatePickerWrapper';
 
-const TestInput = props => (
+const TestInput = (props) => (
   <div style={{ marginTop: 16 }} >
     <input
       {...props}
@@ -28,6 +29,14 @@ const TestInput = props => (
       }}
     />
   </div>
+);
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
 );
 
 storiesOf('SingleDatePicker (SDP)', module)

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -2,8 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from '../examples/SingleDatePickerWrapper';
 
 import { VERTICAL_ORIENTATION, ANCHOR_RIGHT, OPEN_UP } from '../src/constants';
 
@@ -18,7 +19,7 @@ const TestPrevIcon = () => (
       position: 'absolute',
       top: '20px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Prev
   </div>
@@ -35,7 +36,7 @@ const TestNextIcon = () => (
       right: '22px',
       top: '20px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Next
   </div>
@@ -50,6 +51,14 @@ const TestCustomInfoPanel = () => (
   >
     &#x2755; Some useful info here
   </div>
+);
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
 );
 
 storiesOf('SDP - Calendar Props', module)

--- a/stories/SingleDatePicker_day.js
+++ b/stories/SingleDatePicker_day.js
@@ -2,11 +2,12 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 import isSameDay from '../src/utils/isSameDay';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from "../examples/SingleDatePickerWrapper";
 
 const datesList = [
   moment(),
@@ -18,6 +19,14 @@ const datesList = [
   moment().add(12, 'days'),
   moment().add(13, 'days'),
 ];
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
+);
 
 storiesOf('SDP - Day Props', module)
   .add('default', withInfo()(() => (

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -2,8 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from '../examples/SingleDatePickerWrapper';
 
 const TestCustomInputIcon = () => (
   <span
@@ -16,6 +17,14 @@ const TestCustomInputIcon = () => (
   >
     C
   </span>
+);
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
 );
 
 storiesOf('SDP - Input Props', module)

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -239,6 +239,23 @@ describe('CalendarDay', () => {
     });
   });
 
+  describe('#componentDidMount', () => {
+    it('focuses buttonRef after a delay when isFocused and tabIndex is 0', () => {
+      const wrapper = shallow(<CalendarDay isFocused tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidMount({ isFocused: true, tabIndex: 0 });
+      expect(focus.callCount).to.eq(0);
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          expect(focus.callCount).to.eq(1);
+          resolve();
+        }, 0);
+      });
+    });
+  });
+
   describe('#componentDidUpdate', () => {
     it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
       const wrapper = shallow(<CalendarDay isFocused tabIndex={0} />).dive();

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -190,6 +190,23 @@ describe('CustomizableCalendarDay', () => {
     });
   });
 
+  describe('#componentDidMount', () => {
+    it('focuses buttonRef after a delay when isFocused and tabIndex is 0', () => {
+      const wrapper = shallow(<CustomizableCalendarDay isFocused tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidMount({ isFocused: true, tabIndex: 0 });
+      expect(focus.callCount).to.eq(0);
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          expect(focus.callCount).to.eq(1);
+          resolve();
+        }, 0);
+      });
+    });
+  });
+
   describe('#componentDidUpdate', () => {
     it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
       const wrapper = shallow(<CustomizableCalendarDay isFocused tabIndex={0} />).dive();


### PR DESCRIPTION
This was previously only focusing in componentDidUpdate so it would have to wait until something changed before setting the focus on the CalendarDay.  Additionally there is a timing issue where the buttonRef exists but calling focus on it does not work if done during the first tick.  Using setTimeout (vs raf) delays this call just long enough that it is able to fire.